### PR TITLE
Fixed typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         <qk-page data-id="page4">
             <div class="row">
                 <div class="col-md-6 col-md-offset-3">
-                    Go to Quick.JS'<a href="https://github.com/MK2018/QuickJS"> Github </a> and download or clone to repo. We're going to be using the files from the <code>builds/</code> folder, so copy them into your working directory and link to them. Be sure to link the <code>quick.css</code> file in your header, and the <code>quick.js</code> file at the bottom of your page.
+                    Go to Quick.JS'<a href="https://github.com/MK2018/QuickJS"> Github </a> and download or clone the repo. We're going to be using the files from the <code>builds/</code> folder, so copy them into your working directory and link to them. Be sure to link the <code>quick.css</code> file in your header, and the <code>quick.js</code> file at the bottom of your page.
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
"download or clone to repo" became "download or clone the repo", which makes more sense
